### PR TITLE
fix: исправлен разделитель строки в prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,7 @@
     "singleQuote": false,
     "trailingComma": "none",
     "printWidth": 150,
+    "endOfLine": "auto",
     "plugins": ["prettier-plugin-tailwindcss"],
     "overrides": []
 }


### PR DESCRIPTION
На Windows/Unix OS при форматировании нарушался разделитель строки CRLF/LF